### PR TITLE
Add width prop to enable horizontal lazyload

### DIFF
--- a/examples/pages/horizontalScroll.js
+++ b/examples/pages/horizontalScroll.js
@@ -40,7 +40,7 @@ export default class HorizontallScroll extends Component {
         <div className="widget-list horizontal">
           {this.state.arr.map((el, index) => {
             return (
-              <LazyLoad once={el.once} key={index} overflow throttle={100} height={200} offset={500}>
+              <LazyLoad once={el.once} key={index} overflow throttle={100} height={200} offset={500} width={500}>
                 <Widget once={el.once} id={el.uniqueId} count={ index + 1 } />
               </LazyLoad>
             );

--- a/lib/index.js
+++ b/lib/index.js
@@ -356,14 +356,15 @@ var LazyLoad = function (_Component) {
           placeholder = _props2.placeholder,
           className = _props2.className,
           classNamePrefix = _props2.classNamePrefix,
-          style = _props2.style;
+          style = _props2.style,
+          width = _props2.width;
 
 
       return _react2.default.createElement(
         'div',
         { className: classNamePrefix + '-wrapper ' + className, ref: this.setRef, style: style },
         this.visible ? children : placeholder ? placeholder : _react2.default.createElement('div', {
-          style: { height: height },
+          style: { height: height, width: width },
           className: classNamePrefix + '-placeholder'
         })
       );
@@ -388,7 +389,8 @@ LazyLoad.propTypes = {
   placeholder: _propTypes2.default.node,
   scrollContainer: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
   unmountIfInvisible: _propTypes2.default.bool,
-  style: _propTypes2.default.object
+  style: _propTypes2.default.object,
+  width: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string])
 };
 
 LazyLoad.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazyload",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Lazyload your components, images or anything where performance matters.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -335,7 +335,8 @@ class LazyLoad extends Component {
       placeholder,
       className,
       classNamePrefix,
-      style
+      style,
+      width
     } = this.props;
 
     return (
@@ -346,7 +347,7 @@ class LazyLoad extends Component {
           placeholder
         ) : (
           <div
-            style={{ height: height }}
+            style={{ height: height, width: width }}
             className={`${classNamePrefix}-placeholder`}
           />
         )}
@@ -373,7 +374,8 @@ LazyLoad.propTypes = {
   placeholder: PropTypes.node,
   scrollContainer: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   unmountIfInvisible: PropTypes.bool,
-  style: PropTypes.object
+  style: PropTypes.object,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 LazyLoad.defaultProps = {


### PR DESCRIPTION
Add a width prop to LazyLoad component to enable horizontal lazyload.
Just for testing purpose as I'm not sure why this prop is not added to the component by the original creators.